### PR TITLE
better exception handling for commands

### DIFF
--- a/chatbot/commandcenter/commander/commander.py
+++ b/chatbot/commandcenter/commander/commander.py
@@ -69,8 +69,8 @@ class Commander:
             try:
                 command = self.commands[command_string]
                 return command.run(event_pack)
-            except:
-                return "!!! An error occured in the execution of {}. !!!".format(command_string)
+            except Exception as e:
+                return "{} failed. Reason: {}".format(command_string, e)
         else:
             return self.command_not_recognized()
             


### PR DESCRIPTION
Resolves Issue #12 

I wasn't sure on the printing to stdout portion. I think it's overkill right now since the exception message is sent to chat which we currently log in stdout. Do we intend to turn off printing chat messages to stdout at some point?
