### PR TITLE
Try to get bot password from an environment variable, and then fall back to manual entry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 __pycache__
 .pytest_cache
 .vscode
+botpass

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@
 __pycache__
 .pytest_cache
 .vscode
-botpassword

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 __pycache__
 .pytest_cache
 .vscode
+env.sh

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@
 __pycache__
 .pytest_cache
 .vscode
-botpass
+botpassword

--- a/chatbot/botconfig.py
+++ b/chatbot/botconfig.py
@@ -8,8 +8,3 @@ rooms = [
     "#bottest:cclub.cs.wmich.edu",
     "#ccawmunity:cclub.cs.wmich.edu"
 ]
-
-# if you want to stop typing your password every time you start the bot,
-# store the password in an environment variable.
-# run: export BOTPASSWORD=passw0rd in a terminal.
-password_env_variable = "BOTPASSWORD"

--- a/chatbot/botconfig.py
+++ b/chatbot/botconfig.py
@@ -8,3 +8,8 @@ rooms = [
     "#bottest:cclub.cs.wmich.edu",
     "#ccawmunity:cclub.cs.wmich.edu"
 ]
+
+# if you want to stop typing your password every time you start the bot,
+# store the password in an environment variable.
+# run: export BOTPASSWORD=passw0rd in a terminal.
+password_env_variable = "BOTPASSWORD"

--- a/chatbot/chat.py
+++ b/chatbot/chat.py
@@ -11,6 +11,7 @@
 # 11 - Wrong room format.
 # 12 - Couldn't find room.
 
+import os
 import sys
 import logging
 import getpass
@@ -24,6 +25,35 @@ from commandcenter.commander import Commander
 from commandcenter.eventpackage import EventPackage
 
 g_commander = Commander()
+
+def get_password():
+    # try to find password in the BOTPASSWORD environment variable
+    if 'BOTPASSWORD' in os.environ:
+        print("Obtained password from $BOTPASSWORD environment variable.")
+        return os.environ['BOTPASSWORD']
+
+    # try to find password in 'botpass' file in current working directory
+    try:
+        with open('botpassword', 'r') as f:
+            password = f.readline()
+            print("Obtained password from botpass file. (./botpassword)")
+            return password
+    except:
+        # couldn't find file
+        pass
+
+    # user might be running from the root directory of the git repository
+    # try ./chatbot/botpassword
+    try:
+        with open('./chatbot/botpassword', 'r') as f:
+            password = f.readline()
+            print("Obtained password from botpass file. (./chatbot/botpassword)")
+            return password
+    except:
+        # couldn't find file
+        pass
+
+    return getpass.getpass(prompt='Password: ')
 
 # called when a message is recieved.
 def on_message(room, event):
@@ -55,7 +85,7 @@ def on_message(room, event):
 def main():
     client = MatrixClient("https://cclub.cs.wmich.edu")
 
-    password = getpass.getpass(prompt='Password: ')
+    password = get_password()
 
     try:
         client.login_with_password("ccawmu", password)

--- a/chatbot/chat.py
+++ b/chatbot/chat.py
@@ -11,10 +11,10 @@
 # 11 - Wrong room format.
 # 12 - Couldn't find room.
 
-import os
 import sys
 import logging
 import getpass
+from os import environ
 
 import botconfig
 
@@ -29,12 +29,13 @@ from commandcenter.eventpackage import EventPackage
 g_commander = Commander()
 
 def get_password():
-    # try to find password in the BOTPASSWORD environment variable
-    if botconfig.password_env_variable in os.environ:
-        print("Obtained password from ${} environment variable.".format(botconfig.password_env_variable))
-        return os.environ[botconfig.password_env_variable]
-
-    return getpass.getpass(prompt='Password for {}: '.format(botconfig.username))
+    # try to find password in the BOT_PASSWORD environment variable
+    if "BOT_PASSWORD" in environ and environ["BOT_PASSWORD"] is not "":
+        print("Obtained password from BOT_PASSWORD environment variable.")
+        return environ["BOT_PASSWORD"]
+    else:
+        print("No BOT_PASSWORD environment variable has been set.")
+    return getpass.getpass(prompt='Password required for {}: '.format(botconfig.username))
 
 # called when a message is recieved.
 def on_message(room, event):

--- a/chatbot/chat.py
+++ b/chatbot/chat.py
@@ -30,30 +30,9 @@ g_commander = Commander()
 
 def get_password():
     # try to find password in the BOTPASSWORD environment variable
-    if 'BOTPASSWORD' in os.environ:
-        print("Obtained password from $BOTPASSWORD environment variable.")
-        return os.environ['BOTPASSWORD']
-
-    # try to find password in 'botpass' file in current working directory
-    try:
-        with open('botpassword', 'r') as f:
-            password = f.readline()
-            print("Obtained password from botpass file. (./botpassword)")
-            return password
-    except:
-        # couldn't find file
-        pass
-
-    # user might be running from the root directory of the git repository
-    # try ./chatbot/botpassword
-    try:
-        with open('./chatbot/botpassword', 'r') as f:
-            password = f.readline()
-            print("Obtained password from botpass file. (./chatbot/botpassword)")
-            return password
-    except:
-        # couldn't find file
-        pass
+    if botconfig.password_env_variable in os.environ:
+        print("Obtained password from ${} environment variable.".format(botconfig.password_env_variable))
+        return os.environ[botconfig.password_env_variable]
 
     return getpass.getpass(prompt='Password for {}: '.format(botconfig.username))
 

--- a/chatbot/commandcenter/commands/expiry.py
+++ b/chatbot/commandcenter/commands/expiry.py
@@ -26,12 +26,12 @@ class ExpiryCommand(Command):
         if member_UID.isalnum() is not True:
             return "Invalid usage of $expiry: arguments must not contain non-alphanumeric characters"
 
-        LDAP_URI = environ.get("LDAP_URI")
+        LDAP_URL = environ.get("LDAP_URL")
         MEMBER_BASE = environ.get("LDAP_MEMBER_BASE")
         POSIX_DAY = 86400
         DESIRED_FIELDS = ["shadowExpire"]
         tls_config = ldap3.Tls(validate=ssl.CERT_REQUIRED)
-        server = ldap3.Server(LDAP_URI, use_ssl=True, tls=tls_config)
+        server = ldap3.Server(LDAP_URL, use_ssl=True, tls=tls_config)
         conn = ldap3.Connection(server, user=environ.get("LDAP_READONLY_DN"),
                                 password=environ.get("LDAP_READONLY_PASSWORD"),
                                 auto_bind="NONE", read_only=True)

--- a/chatbot/env.sh
+++ b/chatbot/env.sh
@@ -7,7 +7,7 @@
 : <<'END' #begin bash comment
 
 example proper env variable form:
-export MY_ENV_VARIABLE="THIS IS A VALUE"
+export MY_ENV_VARIABLE="THIS-IS-A-VALUE"
 
 example usage of env.sh:
 `source env.sh`

--- a/chatbot/env.sh
+++ b/chatbot/env.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+#this file is intended to be used for sensitive variables only
+#ensure you do not push this file to the repo.
+#all non-sensitive variables should be defined in botconfig.py
+
+
+: <<'END' #begin bash comment
+
+example proper env variable form:
+export MY_ENV_VARIABLE="THIS IS A VALUE"
+
+example usage of env.sh:
+`source env.sh`
+
+example use via python:
+from os import environ
+if "MY_ENV_VARIABLE" in environ:
+    print(environ["MY_ENV_VARIABLE"])
+else:
+    print("environment variable has not been set")
+
+END #end bash comment
+
+
+export BOT_PASSWORD=
+
+#export LDAP_URL=
+#export LDAP_MEMBER_BASE=
+#export LDAP_READONLY_DN=
+#export LDAP_READONLY_PASSWORD=


### PR DESCRIPTION
Addresses #21.

Simply tries to grab the bot password from the BOTPASSWORD (configurable) environment variable. If it can't find it, it simply asks the user to enter the password manually, as before.