### PR TITLE
Add ability to test commands server-side

### DIFF
--- a/chatbot/chat.py
+++ b/chatbot/chat.py
@@ -52,7 +52,7 @@ def on_message(room, event):
             if(event['sender'] == "@ccawmu:cclub.cs.wmich.edu"):
                 return
 
-            # create responses for messages starting with $
+            # create responses for messages starting with the command prefix
             if(event['content']['body'][0] == botconfig.command_prefix):
                 output = event['content']['body'].split(" ")
                 command_string = output[0]

--- a/chatbot/simulate.py
+++ b/chatbot/simulate.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+
+# This script is meant to test commands without having to connect to matrix.
+
+import sys
+
+from commandcenter.commander import Commander
+from commandcenter.eventpackage import EventPackage
+
+import botconfig
+
+print("Loading commander...")
+g_commander = Commander()
+
+def test_message(message, room_id):
+    global g_commander
+
+    sender = '@testcommand-py:cclub.cs.wmich.edu'
+    body = message.split(" ")
+    
+    event_package = EventPackage(body=body, room_id=room_id, sender=sender, event={})
+
+    command_string = body[0]
+
+    if body[0][0] == botconfig.command_prefix:
+        print("Bot output: " + g_commander.run_command(command_string, event_package))
+
+if __name__ == '__main__':
+    room_id = ""
+    if len(sys.argv) >= 2:
+        room_id = sys.argv[1]
+    else:
+        room_id = "#bottest:cclub.cs.wmich.edu"
+
+    print("Simulating room: {}".format(room_id))
+
+    print("Enter chat commands via stdin:")
+
+    message = input()
+    while True:
+        test_message(message, room_id)
+
+        # repeat last command on no input
+        new_mesage = input()
+        if new_mesage != '':
+            message = new_mesage


### PR DESCRIPTION
Addresses #13 

Adds `simulate.py`.

`simulate.py` simply creates a `Commander` instance and accepts stdin as if it was messages sent in a chat room.

By default, it simulates being in `#bottest:cclub.cs.wmich.edu`, but you can change this by passing an argument to the script: `./simulate.py '#ccawmunity:cclub.cs.wmich.edu'`. (Be sure to use quotes, or the `#` will be read as a comment.)

Currently, the ability to change rooms is pretty much useless, but was implemented in preparation for #27.