### PR TITLE
Fix custom prefixes

### DIFF
--- a/chatbot/botconfig.py
+++ b/chatbot/botconfig.py
@@ -1,4 +1,4 @@
-username = "ccawmu"
+username = "spacedog"
 
 client_url = "https://cclub.cs.wmich.edu"
 

--- a/chatbot/botconfig.py
+++ b/chatbot/botconfig.py
@@ -1,8 +1,8 @@
-username = "ccawmu"
+username = "spacedog"
 
 client_url = "https://cclub.cs.wmich.edu"
 
-command_prefix = "$"
+command_prefix = "ABCD"
 
 rooms = [
     "#bottest:cclub.cs.wmich.edu",

--- a/chatbot/botconfig.py
+++ b/chatbot/botconfig.py
@@ -1,8 +1,8 @@
-username = "spacedog"
+username = "ccawmu"
 
 client_url = "https://cclub.cs.wmich.edu"
 
-command_prefix = "ABCD"
+command_prefix = "$"
 
 rooms = [
     "#bottest:cclub.cs.wmich.edu",

--- a/chatbot/botconfig.py
+++ b/chatbot/botconfig.py
@@ -1,4 +1,4 @@
-username = "spacedog"
+username = "ccawmu"
 
 client_url = "https://cclub.cs.wmich.edu"
 

--- a/chatbot/chat.py
+++ b/chatbot/chat.py
@@ -52,8 +52,10 @@ def on_message(room, event):
             if(event['sender'] == "@ccawmu:cclub.cs.wmich.edu"):
                 return
 
-            # create responses for messages starting with $
-            if(event['content']['body'][0] == botconfig.command_prefix):
+            # create responses for messages starting with command prefix
+            # compares the first x characters of a message to the command prefix,
+            # where x = len(command.prefix)
+            if(event['content']['body'][0:len(botconfig.command_prefix)] == botconfig.command_prefix):
                 output = event['content']['body'].split(" ")
                 command_string = output[0]
 

--- a/chatbot/chat.py
+++ b/chatbot/chat.py
@@ -52,7 +52,7 @@ def on_message(room, event):
             if(event['sender'] == "@ccawmu:cclub.cs.wmich.edu"):
                 return
 
-            # create responses for messages starting with command prefix
+            # create responses for messages starting with the command prefix
             # compares the first x characters of a message to the command prefix,
             # where x = len(command.prefix)
             if(event['content']['body'][0:len(botconfig.command_prefix)] == botconfig.command_prefix):

--- a/chatbot/chat.py
+++ b/chatbot/chat.py
@@ -26,7 +26,7 @@ from functools import partial
 from commandcenter.commander import Commander
 from commandcenter.eventpackage import EventPackage
 
-g_commander = Commander()
+g_commander = Commander(botconfig.command_prefix)
 
 def get_password():
     # try to find password in the BOT_PASSWORD environment variable

--- a/chatbot/commandcenter/commander/builtin.py
+++ b/chatbot/commandcenter/commander/builtin.py
@@ -1,0 +1,24 @@
+from ..command import Command
+from ..eventpackage import EventPackage
+
+# dummy classes of the built-in commands so that they are compatible with commands like $help or $info
+
+class HelpCommand(Command):
+    def __init__(self):
+        self.name = "$help" # this is required in order for the command to run!
+        self.help = "$help | Learn how to use commands. | Usage: $help or $help <command (including the $)>"
+        self.author = "spacedog"
+        self.last_updated = "Oct. 11, 2018"
+
+    def run(self, event_pack: EventPackage):
+        return "This command is built in to the commander. You should never see this text. Uh oh."
+
+class InfoCommand(Command):
+    def __init__(self):
+        self.name = "$info" # this is required in order for the command to run!
+        self.help = "$info | Display info about a command. | Usage: $info <command (including the $)>"
+        self.author = "spacedog"
+        self.last_updated = "Oct. 11, 2018"
+
+    def run(self, event_pack: EventPackage):
+        return "This command is built in to the commander. You should never see this text. Uh oh."

--- a/chatbot/commandcenter/commander/commander.py
+++ b/chatbot/commandcenter/commander/commander.py
@@ -7,98 +7,79 @@ from os.path import isfile, join, abspath, dirname
 # important! this is where we discover all of the commands in the command directory.
 # if this isn't called, Command.__subclasses__() is empty.
 from ..commands import *
+from .builtin import *
 
 from ..command import Command
 from ..eventpackage import EventPackage
 
-# dummy classes of the built-in commands so that they are compatible with commands like $help or $info
-
-class HelpCommand(Command):
-    def __init__(self):
-        self.name = "$help" # this is required in order for the command to run!
-        self.help = "$help - Learn about commands. Usage: `$help` or `$help <command (including the dollar sign)>`"
-        self.author = "spacedog"
-        self.last_updated = "Sept. 28, 2018"
-
-    def run(self, event_pack: EventPackage):
-        return "This command is built in to the commander. You should never see this text. Uh oh."
-
-class InfoCommand(Command):
-    def __init__(self):
-        self.name = "$info" # this is required in order for the command to run!
-        self.help = "$info - Display info about a command. Usage: `$info <command (including the dollar sign)>`"
-        self.author = "spacedog"
-        self.last_updated = "Sept. 28, 2018"
-
-    def run(self, event_pack: EventPackage):
-        return "This command is built in to the commander. You should never see this text. Uh oh."
-
 class Commander:
-    def __init__(self):
+    def __init__(self, prefix = "$"):
         self.commands = {}
+        self.prefix = prefix
+
+        print("Prefix: " + self.prefix)
 
         for command_class in Command.__subclasses__():
             command = command_class()
             self.commands[command.get_name()] = command
-            print("Loaded command: " + command.get_name())
+
+        print("Commander loaded with commands:")
+        print(self.get_help_all())
 
     def run_command(self, command_string, event_pack: EventPackage):
-        print("Commander: running command: {0}".format(command_string))
+        # convert command string to use $ as prefix in order to work with the internal syntax
+        command_string_normalized = command_string.replace(self.prefix, "$")
 
-        if command_string == "$commands":
+        print("Commander: running command: {0}".format(command_string_normalized))
+
+        if command_string_normalized == "$commands":
             print("Built in command: $commands")
-            return self.get_help_string()
+            return self.get_help_all()
 
-        if command_string == "$help":
+        if command_string_normalized == "$help":
             print("Built in command: $help")
             if len(event_pack.body) >= 2:
-                command_string = event_pack.body[1]
+                return self.get_help(event_pack.body[1].replace(self.prefix, "$"))
             else:
-                command_string = ''
-            return self.get_help_string(command_string)
+                return self.get_help_all()
 
-        if command_string == "$info":
+        if command_string_normalized == "$info":
             print("Built in command: $info")
             if len(event_pack.body) >= 2:
-                command_string = event_pack.body[1]
+                return self.get_info(event_pack.body[1].replace(self.prefix, "$"))
             else:
                 return "You must specify a command!"
-            return self.get_info(command_string)
 
-        if command_string in self.commands:
+        if command_string_normalized in self.commands:
             try:
-                command = self.commands[command_string]
+                command = self.commands[command_string_normalized]
                 return command.run(event_pack)
             except Exception as e:
-                return "{} failed. Reason: {}".format(command_string, e)
+                return "{} failed. Reason: {}".format(command_string_normalized, e)
         else:
             return self.command_not_recognized()
             
     def get_help(self, command_string):
         if command_string in self.commands:
-            return self.commands[command_string].get_help()
+            return self.commands[command_string].get_help().replace("$", self.prefix)
         else:
             return self.command_not_recognized()
 
     def get_info(self, command_string):
         if command_string in self.commands:
             command = self.commands[command_string]
-            output = "Info for `" + command_string + "`...\n"
+            output = "Info for " + command_string.replace("$", self.prefix) + "...\n"
             output += "Last updated: " + command.get_last_updated() + "\n"
             output += "Author: " + command.get_author() + "\n"
             return output
         else:
             return self.command_not_recognized()
 
-    def get_help_string(self, command_string = ''):
-        if command_string == '':
-            command_list = ""
-            for label in self.commands:
-                command = self.commands[label]
-                command_list += command.get_help() + '\n'
-            return command_list
-        else:
-            return self.get_help(command_string)
+    def get_help_all(self):
+        command_list = ""
+        for label in self.commands:
+            command_list += self.get_help(label) + "\n"
+        return command_list
 
     def command_not_recognized(self):
-        return "Command not recognized, please try \"$commands\" for available commands"
+        return "Command not recognized, please try \"$help\" for available commands".replace("$", self.prefix)


### PR DESCRIPTION
Addresses #33.

This PR allows the user to specify a custom prefix in `botconfig.py`.

Simply set the `command_prefix` variable to a desired string.

Under the hood, it works by converting any command with a custom prefix to a format that uses `$` as a prefix. This way, users writing commands don't have to worry about prefixes. They just use `$`. The Commander will recognize the `$`'s present and replace them on the fly.