### PR TITLE
Command timeouts (and also brainfuck)

### DIFF
--- a/chatbot/botconfig.py
+++ b/chatbot/botconfig.py
@@ -2,6 +2,9 @@ username = "ccawmu"
 
 client_url = "https://cclub.cs.wmich.edu"
 
+# seconds before a command times out and is killed
+command_timeout = 3
+
 command_prefix = "$"
 
 rooms = [

--- a/chatbot/chat.py
+++ b/chatbot/chat.py
@@ -29,7 +29,7 @@ from commandcenter.eventpackage import EventPackage
 
 from listenercenter.listenermanager import ListenerManager
 
-g_commander = Commander(botconfig.command_prefix)
+g_commander = Commander(botconfig.command_prefix, botconfig.command_timeout)
 
 def get_password():
     # try to find password in the BOT_PASSWORD environment variable

--- a/chatbot/commandcenter/commander/commander.py
+++ b/chatbot/commandcenter/commander/commander.py
@@ -72,7 +72,7 @@ class Commander:
                 # terminating the process corrupts the pipe created above. 
                 # this is fine as long as we don't use it again.
                 p.terminate() 
-                return self.command_timed_out()
+                return self.command_timed_out(command.get_name())
 
             # if the process wasn't terminated, it's return result will be in the pipe.
             return recv_end.recv()
@@ -112,5 +112,5 @@ class Commander:
     def command_not_recognized(self):
         return "Command not recognized, please try \"$help\" for available commands".replace("$", self.prefix)
 
-    def command_timed_out(self):
-        return f"Command timed out. (Command time limit is {self.timeout} seconds.)"
+    def command_timed_out(self, command_string):
+        return f"{command_string} timed out. (Command time limit is {self.timeout} seconds.)"

--- a/chatbot/commandcenter/commands/brainfuck.py
+++ b/chatbot/commandcenter/commands/brainfuck.py
@@ -1,0 +1,65 @@
+from ..command import Command
+from ..eventpackage import EventPackage
+
+# stolen from https://github.com/pocmo/Python-Brainfuck/blob/master/brainfuck.py
+
+import sys
+
+def evaluate(code):
+  code     = cleanup(list(code))
+  bracemap = buildbracemap(code)
+  result   = ""
+
+  cells, codeptr, cellptr = [0], 0, 0
+
+  while codeptr < len(code):
+    command = code[codeptr]
+
+    if command == ">":
+      cellptr += 1
+      if cellptr == len(cells): cells.append(0)
+
+    if command == "<":
+      cellptr = 0 if cellptr <= 0 else cellptr - 1
+
+    if command == "+":
+      cells[cellptr] = cells[cellptr] + 1 if cells[cellptr] < 255 else 0
+
+    if command == "-":
+      cells[cellptr] = cells[cellptr] - 1 if cells[cellptr] > 0 else 255
+
+    if command == "[" and cells[cellptr] == 0: codeptr = bracemap[codeptr]
+    if command == "]" and cells[cellptr] != 0: codeptr = bracemap[codeptr]
+    if command == ".": result += chr(cells[cellptr])
+    if command == ",": pass # can't really do stdin in chat... or can we?
+      
+    codeptr += 1
+
+  return result
+
+def cleanup(code):
+  return ''.join(filter(lambda x: x in ['.', ',', '[', ']', '<', '>', '+', '-'], code))
+
+def buildbracemap(code):
+  temp_bracestack, bracemap = [], {}
+
+  for position, command in enumerate(code):
+    if command == "[": temp_bracestack.append(position)
+    if command == "]":
+      start = temp_bracestack.pop()
+      bracemap[start] = position
+      bracemap[position] = start
+  return bracemap
+
+class BrainfuckCommand(Command):
+    def __init__(self):
+        self.name = "$brainfuck" # this is required in order for the command to run!
+        
+        # define what will be shown when someone calls "help $<your command>"
+        self.help = "$brainfuck | brainfuck interpreter. \',\' instruction ignored. | usage: $brainfuck +[-[<<[+[--->]-[<<<]]]>>>-]>-.---.>..>.<<<<-.<+.>>>>>.>.<<.<-."
+        
+        self.author = "spacedog"
+        self.last_updated = "Nov 26, 2018"
+
+    def run(self, event_pack: EventPackage):
+        return evaluate(''.join(event_pack.body[1:]))


### PR DESCRIPTION
I added a brainfuck command.

I then realized that it is possible to create infinite loops with brainfuck, so that there would have to be some kind of timeout functionality added to prevent any malicious brainfuckers from getting the bot stuck in an infinite loop.

---

The brainfuck command simply interprets brainfuck and outputs the result. Example:
```
spacedog: $brainfuck +[-[<<[+[--->]-[<<<]]]>>>-]>-.---.>..>.<<<<-.<+.>>>>>.>.<<.<-.
ccawmunity: hello world
```
Thankfully, the interpreter that I stole is pretty resistant to bad input:
```
# equivalent to the above example
spacedog: $brainfuck +[-[<<[+[           --->]-[<<<]]]>>>-]>-.-           --.>..>.< foo <<<         -.<+.>>>>>.>.<<.<-.
ccawmunity: hello world
```
---
The timeout functionality adds a field to `botconfig.py`. `command_timeout` specifies how long a command can run before it gets killed.

The commander now fires off commands on separate processes and kills the process if it runs too long. If a process gets killed, a message is sent to the chat room indicating so.

Example:
```
brainfucker: $brainfuck +[]
ccawmunity: $brainfuck timed out. (Command time limit is 3 seconds.)
```