### PR TITLE
Topic Command

### DIFF
--- a/chatbot/chat.py
+++ b/chatbot/chat.py
@@ -81,6 +81,7 @@ def send_geeks_welcome_message(member):
 
 def on_message(room, event):
     global g_commander
+    global g_client
 
     if event['type'] == "m.room.member":
         if event['content']['membership'] == "join":
@@ -114,6 +115,19 @@ def on_message(room, event):
 
                 response = g_commander.run_command(
                     command_string, event_package)
+
+                #hack: need to change topic here for some reason
+                if command_string == "$topic":
+                    if response[0] == "ERR":
+                        print("! [TOPIC] {}".format(response[1]))
+                        return
+                    elif response[0] == "TOP":
+                        g_client.get_rooms()[event["room_id"]].set_room_topic(response[1])
+                        return
+                    elif response[0] == "MSG":
+                        response = response[1]
+                    else:
+                        print("! [TOPIC] SOMETHING CATASTROPHIC OCCURRED!")
 
                 # don't spam #geeks
                 if event['room_id'] == botconfig.ROOM_ID_GEEKS:

--- a/chatbot/commandcenter/command/command.py
+++ b/chatbot/commandcenter/command/command.py
@@ -46,6 +46,9 @@ class Command:
     def db_get(self, key):
         return redis.get(self._db_create_namespaced_key(key))
 
+    def db_del(self, key):
+        return redis.delete(self._db_create_namespaced_key(key))
+
     def db_incr(self, key):
         return redis.incr(self._db_create_namespaced_key(key))
 
@@ -78,11 +81,20 @@ class Command:
     def db_list_len(self, list):
         return redis.llen(self._db_create_namespaced_key(list))
 
+    def db_list_set(self, list, index, key):
+        return redis.lset(self._db_create_namespaced_key(list), index, key)
+
+    def db_list_rem(self, list, num, key):
+        return redis.lrem(self._db_create_namespaced_key(list), num, key)
+
     def db_list_idx(self, list, index):
         return redis.lindex(self._db_create_namespaced_key(list), index)
 
     def db_list_range(self, list, start, end):
         return redis.lrange(self._db_create_namespaced_key(list), start, end)
+
+    def db_list_trim(self, list, start, end):
+        return redis.ltrim(self._db_create_namespaced_key(list), start, end)
     
     # shortcut to get whole list
     def db_list_get(self, key):

--- a/chatbot/commandcenter/commands/topic.py
+++ b/chatbot/commandcenter/commands/topic.py
@@ -1,0 +1,95 @@
+from ..command import Command
+from ..eventpackage import EventPackage
+
+class TopicCommand(Command):
+    def __init__(self):
+        self.name = "$topic"
+        self.help = "$topic | modify the current channel topic"
+        self.author = "sphinx"
+        self.last_updated = "May 16, 2020"
+        self.whitelist = ["alu", "spacedog", "sphinx"]
+
+    def run(self, event_pack: EventPackage):
+        args = event_pack.body[1:]
+        room = event_pack.room_id.split(":")[0][1:]
+        nick = event_pack.sender.split(":")[0][1:]
+
+        if len(args) > 0:
+            if args[0][0] == "-" and len(args[0]) == 2:
+                switch = args[0][1].lower()
+
+                # admin check
+                if not nick in self.whitelist:
+                    return ("ERR", "USER NOT IN WHITELIST")
+
+                # delete some topic
+                if switch == "d":
+                    if len(args) > 1:
+                        try:
+                            index = int(args[1])
+                        except ValueError:
+                            return ("ERR", "INDEX NOT AN INTEGER")
+
+                        # delete topic at specific index...
+                        self._delete_at(room, index)
+                    else:
+                        # ...or delete last (presumably oldest) topic
+                        self._delete_last(room)
+                    # update topic
+                    return ("TOP", self._get_topic(room))
+                # refresh the current topic (possibly edited manually)
+                elif switch == "r":
+                    return ("TOP", self._get_topic(room))
+                # approve proposal
+                elif switch == "y":
+                    proposed = self.db_get(room + ":proposed")
+                    if proposed is not None:
+                        self.db_del(room + ":proposed")
+                        add = str(proposed, "UTF-8")
+                        self.db_lpush(room, add)
+                        return ("TOP", self._get_topic(room))
+                    else:
+                        return ("ERR", "NO TOPIC PROPOSED")
+                # disapprove proposal
+                elif switch == "n":
+                    self.db_del(room + ":proposed")
+                    return ("ERR", "PROPOSAL REMOVED")
+                # show proposed topic
+                elif switch == "p":
+                    proposed = self.db_get(room + ":proposed")
+                    if proposed is not None:
+                        add = str(proposed, "UTF-8")
+                        return ("MSG", "topic proposed, awaiting approval: {}".format(add))
+                    else:
+                        return ("ERR", "NO TOPIC PROPOSED")
+                # given switch is unknown
+                else:
+                    return ("ERR", "UNKNOWN SWITCH {}".format(args[0]))
+            else:
+                # join up all the arguments, it is the new topic
+                add = " ".join(args)
+
+                # if user is in whitelist, just add topic
+                if nick in self.whitelist:
+                    self.db_lpush(room, add)
+                    return ("TOP", self._get_topic(room))
+                # otherwise propose topic
+                else:
+                    self.db_set(room + ":proposed", add)
+                    return ("MSG", "topic proposed, awaiting approval: {}".format(add))
+
+        else:
+            return ("ERR", "NO ARGUMENTS GIVEN")
+
+    # obtain topic list from redis, delimit with pipes
+    def _get_topic(self, room):
+        return " | ".join(str(x, "UTF-8") for x in self.db_list_get(room))
+
+    # delete topic from a specific index
+    def _delete_at(self, room, index):
+        self.db_list_set(room, index, "__DELETED__")
+        self.db_list_rem(room, 1, "__DELETED__")
+
+    # delete the last (presumably oldest) topic
+    def _delete_last(self, room):
+        self.db_list_trim(room, 0, -2)


### PR DESCRIPTION
Added a topic command. Whitelist is internal and global for now. Think this theoretically will work if the bot is managing topic in multiple channels. Plebs can only propose topic and it just stores the most recent proposal and is overwritten every time.

**$topic \<words\>**: propose topic addition or directly add if whitelisted

The rest of these are whitelisted nicks only
**$topic -d \#\#**: delete specific topic, indexed at 0 from left to right (newest to oldest), if no ## given, oldest topic is deleted
**$topic -r**: refresh topic in case it was messed with and needs to be restored
**$topic -y**: approve proposed topic addition
**$topic -n**: disapprove proposed topic addition
**$topic -p**: restate current proposal