### PR TITLE
Wordle: Ignore extra whitespace when getting guess

### DIFF
--- a/chatbot/commandcenter/commands/wordle.py
+++ b/chatbot/commandcenter/commands/wordle.py
@@ -128,7 +128,7 @@ class WordleCommand(Command):
             pts_s = nick + ", you have " + str(pts) + " points."
             return CCR(pts_s + "\n" + self.chart())
         
-        word = body[1].lower()
+        word = ''.join(body[1].lower().split())
         if len(word) != 5:
             # invalid length
             return CCR("Guesses have to be 5 letter words.")


### PR DESCRIPTION
Strip whitespace before saving input to variable. This eliminates the issue of an extra space between the command and the argument causing an error.