### PR TITLE
Changed POST to GET in Office Command

### DIFF
--- a/chatbot/commandcenter/commands/office.py
+++ b/chatbot/commandcenter/commands/office.py
@@ -20,7 +20,7 @@ class OfficeCommand(Command):
         if data:
             return requests.post(full_url, data=data)
         else:
-            return requests.post(full_url)
+            return requests.get(full_url)
 
     def run(self, event_pack: EventPackage):
         r = ""


### PR DESCRIPTION
Fixed bug introduced by #95 where office `query()` function used a `POST` request when it should have used a `GET` request