### PR TITLE
added command to add a new member to the ccowmu github organization

### DIFF
--- a/chatbot/commandcenter/commands/git_add.py
+++ b/chatbot/commandcenter/commands/git_add.py
@@ -1,0 +1,38 @@
+from ..command import Command
+from ..eventpackage import EventPackage
+from .github_token import BEARER_TOKEN
+import requests
+
+class GitAddCommand(Command):
+    def __init__(self):
+        super().__init__()
+
+        self.name = "$git_add"
+        self.help = "$git_add | Adds a user to the ccowmu github by email | Usage: $git_add <email>"
+        self.author = "bmo"
+        self.last_updated = "Feb 19, 2024"
+        
+        self.base_url = "https://api.github.com/orgs/ccowmu/invitations"
+        self.headers = {
+            'Accept': 'application/vnd.github+json',
+            'Authorization': f'Bearer {BEARER_TOKEN}',
+            'X-GitHub-Api-Version': '2022-11-28'
+        }
+        self.data = {
+            'role': 'direct_member'
+        }
+
+    def run(self, event_pack: EventPackage):
+        # should always receive 2 args
+        if len(event_pack.body) == 2:
+            self.data['email'] = event_pack.body[1]
+
+            response = requests.post(self.base_url, headers=self.headers, json=self.data)
+
+            if not response.ok:
+                return f'Failed to send invitation: {response.status_code} - {response.text}'
+
+            return "Invitation sent"
+        else:
+            return "Invalid input: Usage: $git_add <email>"
+            

--- a/chatbot/commandcenter/commands/github_token.py
+++ b/chatbot/commandcenter/commands/github_token.py
@@ -1,0 +1,2 @@
+# token used to add member to gihub organization
+BEARER_TOKEN = "It's a secret"


### PR DESCRIPTION
$git_add command can be used to add a "direct_member" to the org. github_token.py will get an environment variable on load which will have the token that allows a github invite.